### PR TITLE
Added link to the /en section

### DIFF
--- a/index.html
+++ b/index.html
@@ -5,3 +5,7 @@ layout:     default
 <script>
   window.location.href = window.location.href + 'en';
 </script>
+
+<div class="row mx-3">
+  <a class="col-12 col-md-6 p-3 border border-secondary" href="/en">View site in English</a>
+</div>

--- a/pages/en/resources/electronic.md
+++ b/pages/en/resources/electronic.md
@@ -5,7 +5,7 @@ ref:        electronic-resources
 title:      Electronic Resources
 parent:     resources
 breadcrumb: true
-permalink:  /en/resources/electronic/
+permalink:  /en/resources/electronic-resources/
 ---
 
 {% include article-short-list.html


### PR DESCRIPTION
Few bits addressed:
- I suspect the JS redirect to impact the crawler
- moved Electronic Resources to `electronic-resources` (feel free to comment)